### PR TITLE
multifield reindex fix

### DIFF
--- a/src/Cms/Form/Element/MultiField.php
+++ b/src/Cms/Form/Element/MultiField.php
@@ -200,18 +200,25 @@ class MultiField extends \Mmi\Form\Element\ElementAbstract
                     e.preventDefault();
                     list.append('$listElement'.replaceAll('**', list.children().length));
                 });
-                
+
                 function reindex() {
                     list.children().each(function(i) {
-                        let elementWithId = $('[id]', this);
-                        elementWithId.attr('id', elementWithId.attr('id').replace(/-\d+-/ig, '-' + i + '-'));
-                        let elementWithFor = $('[for]', this);
-                        elementWithFor.attr('for', elementWithFor.attr('for').replace(/-\d+-/ig, '-' + i + '-'));
-                        let elementWithName  = $('[name]', this);
-                        elementWithName .attr('name', elementWithName .attr('name').replace(/\[\d+\]/ig, '[' + i + ']'));
+                        let elementsWithId = $('[id]', this);                      
+                        elementsWithId.each(function(){
+                            $(this).attr('id', $(this).attr('id').replace(/-\d+-/ig, '-' + i + '-'));
+                        });
+                        
+                        let elementsWithFor = $('[for]', this);
+                        elementsWithFor.each(function(){
+                            $(this).attr('for', $(this).attr('for').replace(/-\d+-/ig, '-' + i + '-'));
+                        });
+                        
+                        let elementsWithName  = $('[name]', this);   
+                        elementsWithName.each(function(){
+                            $(this).attr('name', $(this).attr('name').replace(/\[\d+\]/ig, '[' + i + ']'));
+                        });
                     });
                 }
-                
             });    
 html;
     }


### PR DESCRIPTION
w pierwotnej wersji wszystkie pola z danego zestawu miały podmienianą nazwę na zgodną z pierwszym polem w tym zestawie, czyli jeśli np było tak:
widgetarticleindex-form-widgetform-articles-0-source
widgetarticleindex-form-widgetform-articles-0-template
widgetarticleindex-form-widgetform-articles-1-source
widgetarticleindex-form-widgetform-articles-1-template

to po podmianie było tak:
widgetarticleindex-form-widgetform-articles-0-source
widgetarticleindex-form-widgetform-articles-0-source
widgetarticleindex-form-widgetform-articles-1-source
widgetarticleindex-form-widgetform-articles-1-source

przez to po usunięciu jednego zestawu (np kafla) wszystkie wartości się czyściły bo nagle miały to samo id i name itd.