### PR TITLE
multifield validation loop fix

### DIFF
--- a/src/Cms/Form/Element/MultiField.php
+++ b/src/Cms/Form/Element/MultiField.php
@@ -81,7 +81,7 @@ class MultiField extends \Mmi\Form\Element\ElementAbstract
                 $value = $itemValues[$element->getBaseName()] ?? null;
                 //waliduje poprawnie jeśli niewymagane, ale tylko gdy niepuste
                 if (empty($value) && false === $element->getRequired()) {
-                    return $result;
+                    continue;
                 }
                 //iteracja po walidatorach
                 foreach ($element->getValidators() as $validator) {


### PR DESCRIPTION
poprawka do walidacji w multifield - w pierwotnej wersji jeśli pętla przechodząca po wszystkich polach natrafiała na pierwsze pole, które nie było wymagane i nie miało wartości, to walidacja była przerywana i kolejne pola nie były sprawdzane