### PR TITLE
multifield checkboxes fix

### DIFF
--- a/src/Cms/Form/Element/MultiField.php
+++ b/src/Cms/Form/Element/MultiField.php
@@ -170,6 +170,11 @@ class MultiField extends \Mmi\Form\Element\ElementAbstract
             $element->setName($this->getBaseName() . '[' . $index . '][' . $element->getBaseName() . ']');
             $element->setValue($itemValues[$element->getBaseName()] ?? null);
             $element->setErrors($this->_elementErrors[$index][$element->getBaseName()] ?? []);
+
+            if ($element instanceof Checkbox) {
+                $element->getValue() ? $element->setChecked() : $element->setChecked(false);
+            }
+
             $html .= $element->__toString();
         }
 


### PR DESCRIPTION
w pierwotnej wersji checkboxy w multifield się zapisywały, ale przy odczycie recordu w formularzu nie były zaznaczone